### PR TITLE
Make the generated pdf file can only saved locally instead always downloaded

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,18 +20,30 @@ function setHeader(res, filename){
 }
 function sendHTMLPDF(res, filename, content, options){
     return new Promise(function(resolve, reject){
-        setHeader(res, filename);
-        pdf.create(content, options).toStream(function(err, stream){
-            if(err){
-                reject(err);
-            }else{
-                stream.pipe(res);
-                stream.on('end', function(){
+        if(!options.directory)
+            setHeader(res, filename);
+        if(options.directory){
+            pdf.create(content, options).toFile(options.directory+filename, function(err, response){
+                if(err){
+                    reject(err);
+                }else{
                     res.end();
                     resolve();
-                })
-            }
-        });
+                }
+            });
+        } else {
+            pdf.create(content, options).toStream(function(err, stream){
+                if(err){
+                    reject(err);
+                }else{
+                    stream.pipe(res);
+                    stream.on('end', function(){
+                        res.end();
+                        resolve();
+                    })
+                }
+            });
+        }
     });
 }
 


### PR DESCRIPTION
When calling `res.pdfFromHTML`, the generated pdf file always downloaded even the `directory` passed to `options` just like [html-pdf#option](https://www.npmjs.com/package/html-pdf#options) said:
`"directory": "/tmp",       // The directory the file gets written into if not using .toFile(filename, callback). default: '/tmp'`

Now, if the options.directory is available, the file will only saved locally instead downloaded directly.

## Why ?
Sometimes we need this for sending the file as an attachment in email, for example as an invoice.